### PR TITLE
Fix typo that always disabled IPO

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,8 +10,8 @@ endif()
 include(CheckIPOSupported)
 check_ipo_supported(RESULT HAS_IPO)
 
-if(HAS_IP)
-    set_property(TARGET ssolve sudoku_solve 
+if(HAS_IPO)
+    set_property(TARGET ssolve sudoku_solve
         PROPERTY INTERPROCEDURAL_OPTIMIZATION TRUE)
 endif()
 


### PR DESCRIPTION
I saw your repo linked in a blog post about SAT solvers—an interesting read—and noticed a typo in the `src/CMakeLists.txt` file that led to inter-procedural optimizations always being disabled.